### PR TITLE
update: Add migration to enable record entry in Delivery Note

### DIFF
--- a/xml/migration/5030_LVE_Enable_Record_Entry_in_Delivery_Note_Window.xml
+++ b/xml/migration/5030_LVE_Enable_Record_Entry_in_Delivery_Note_Window.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="LVE" Name="LVE_Enable record entry in the Delivery Note" ReleaseNo="3.9.4" SeqNo="81001370">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="106" Action="U" Record_ID="55264" Table="AD_Tab">
+        <Data AD_Column_ID="13994" Column="IsInsertRecord" oldValue="false">true</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
- Se agrega un archivo XML que habilita la opción "Ingresar Registros" en la ventana de Nota de Entregas, permitiendo la creación de registros directamente desde la interfaz.