### PR TITLE
feat: Add validation to prevent voiding completed fiscal sales invoices

### DIFF
--- a/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
+++ b/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
@@ -1,6 +1,6 @@
 /************************************************************************************
  * Copyright (C) 2012-2026 E.R.P. Consultores y Asociados, C.A.                     *
- * Contributor(s): Yamel Senih ysenih@erpya.com                                     *
+ * Contributor(s): Jesús Albujas, jesusramirez35000@gmail.com                                     *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
  * the Free Software Foundation, either version 2 of the License, or                *

--- a/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
+++ b/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
@@ -81,7 +81,7 @@ public class FiscalSalesInvoice implements ModelValidator {
 						&& MInvoice.DOCSTATUS_Completed.equals(invoice.getDocStatus())
 						&& documentType.get_ValueAsBoolean(LVEUtil.COLUMNNAME_IsFiscalDocument)) {
 
-					throw new AdempiereException("Cannot void or reverse a completed fiscal sales document");
+					throw new AdempiereException("@ActionNotAllowed@ - @IsFiscalDocument@ @Completed@: " + invoice.getDocumentNo());
 				}
 			}
 		}

--- a/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
+++ b/core/src/main/java/base/org/erpya/lve/model/validator/FiscalSalesInvoice.java
@@ -1,0 +1,90 @@
+/************************************************************************************
+ * Copyright (C) 2012-2026 E.R.P. Consultores y Asociados, C.A.                     *
+ * Contributor(s): Yamel Senih ysenih@erpya.com                                     *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+package org.erpya.lve.model.validator;
+
+import org.adempiere.core.domains.models.I_C_Invoice;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MClient;
+import org.compiere.model.MDocType;
+import org.compiere.model.MInvoice;
+import org.compiere.model.ModelValidationEngine;
+import org.compiere.model.ModelValidator;
+import org.compiere.model.PO;
+import org.compiere.util.CLogger;
+import org.erpya.lve.util.LVEUtil;
+
+/**
+ * Validator to prevent voiding and reversing completed fiscal sales invoices.
+ * 
+ * @author Jesús Albujas, jesusramirez35000@gmail.com
+ *
+ */
+public class FiscalSalesInvoice implements ModelValidator {
+
+	/** Logger */
+	private static CLogger log = CLogger.getCLogger(FiscalSalesInvoice.class);
+	/** Client */
+	private int clientId = -1;
+
+	@Override
+	public void initialize(ModelValidationEngine engine, MClient client) {
+		// client = null for global validator
+		if (client != null) {
+			clientId = client.getAD_Client_ID();
+			log.info(client.toString());
+		} else {
+			log.info("Initializing global validator: " + this.toString());
+		}
+		// Add Document Validate
+		engine.addDocValidate(I_C_Invoice.Table_Name, this);
+	}
+
+	@Override
+	public int getAD_Client_ID() {
+		return clientId;
+	}
+
+	@Override
+	public String login(int AD_Org_ID, int AD_Role_ID, int AD_User_ID) {
+		log.info("AD_User_ID=" + AD_User_ID);
+		return null;
+	}
+
+	@Override
+	public String modelChange(PO entity, int type) throws Exception {
+		return null;
+	}
+
+	@Override
+	public String docValidate(PO entity, int timing) {
+		if (timing == TIMING_BEFORE_VOID || timing == TIMING_BEFORE_REVERSEACCRUAL
+				|| timing == TIMING_BEFORE_REVERSECORRECT) {
+			if (entity.get_TableName().equals(I_C_Invoice.Table_Name)) {
+				MInvoice invoice = (MInvoice) entity;
+				int c_DocType_ID = invoice.getC_DocTypeTarget_ID() == 0 ? invoice.getC_DocType_ID()
+						: invoice.getC_DocTypeTarget_ID();
+				MDocType documentType = MDocType.get(entity.getCtx(), c_DocType_ID);
+
+				if (invoice.isSOTrx()
+						&& MInvoice.DOCSTATUS_Completed.equals(invoice.getDocStatus())
+						&& documentType.get_ValueAsBoolean(LVEUtil.COLUMNNAME_IsFiscalDocument)) {
+
+					throw new AdempiereException("Cannot void or reverse a completed fiscal sales document");
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/base/org/erpya/lve/setup/FiscalSalesInvoiceValidation.java
+++ b/core/src/main/java/base/org/erpya/lve/setup/FiscalSalesInvoiceValidation.java
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Jesús Albujas jesusramirez35000@gmail.com                  *
+ *****************************************************************************/
+package org.erpya.lve.setup;
+
+import java.util.Properties;
+
+import org.compiere.model.Query;
+import org.adempiere.core.domains.models.X_AD_ModelValidator;
+import org.erpya.lve.model.validator.FiscalSalesInvoice;
+import org.spin.util.ISetupDefinition;
+
+/**
+ * Setup class for Fiscal Sales Invoice Validation
+ * 
+ * @author Jesús Albujas, jesusramirez35000@gmail.com
+ */
+public class FiscalSalesInvoiceValidation implements ISetupDefinition {
+
+	private static final String SETUP_DESCRIPTION = "(*Created from Setup Automatically*)";
+	private static final String SETUP_UUID = "(*AutomaticSetup*)";
+
+	@Override
+	public String doIt(Properties context, String transactionName) {
+		// Add Model Validator
+		createModelValidator(context, transactionName);
+		return "@AD_SetupDefinition_ID@ @Ok@";
+	}
+
+	/**
+	 * Create Model Validator
+	 * 
+	 * @param context
+	 * @param transactionName
+	 * @return
+	 */
+	private X_AD_ModelValidator createModelValidator(Properties context, String transactionName) {
+		X_AD_ModelValidator modelValidator = new Query(context, X_AD_ModelValidator.Table_Name,
+				X_AD_ModelValidator.COLUMNNAME_ModelValidationClass + " = ?", transactionName)
+				.setParameters(FiscalSalesInvoice.class.getName())
+				.setClient_ID()
+				.<X_AD_ModelValidator>first();
+		// Validate
+		if (modelValidator != null
+				&& modelValidator.getAD_ModelValidator_ID() > 0) {
+			return modelValidator;
+		}
+		//
+		modelValidator = new X_AD_ModelValidator(context, 0, transactionName);
+		modelValidator.setName("Prevent Void/Reverse Fiscal Sales Invoice");
+		modelValidator.setEntityType("LVE");
+		modelValidator.setDescription(SETUP_DESCRIPTION);
+		modelValidator.setSeqNo(201);
+		modelValidator.setModelValidationClass(FiscalSalesInvoice.class.getName());
+		modelValidator.setUUID(SETUP_UUID);
+		modelValidator.setIsDirectLoad(true);
+		modelValidator.saveEx();
+		return modelValidator;
+	}
+}

--- a/xml/migration/5040_LVE_Validacion_para_prevenir_reverso_de_facturas_fiscales.xml
+++ b/xml/migration/5040_LVE_Validacion_para_prevenir_reverso_de_facturas_fiscales.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Validacion para prevenir reverso de facturas fiscales" ReleaseNo="3.9.4" SeqNo="81001380">
+  <Migration EntityType="LVE" Name="Validacion para prevenir reverso de facturas fiscales" ReleaseNo="3.9.4" SeqNo="81001380">
     <Comments>para</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54786" Action="I" Record_ID="50139" Table="AD_SetupDefinition">
@@ -11,7 +11,7 @@
         <Data AD_Column_ID="97368" Column="Created">2026-04-13 11:42:07.376</Data>
         <Data AD_Column_ID="97369" Column="CreatedBy">100</Data>
         <Data AD_Column_ID="97370" Column="Description">Este setup impide anular o revertir facturas de venta fiscales, asegurando la integridad de la información y forzando el uso de notas de crédito para correcciones.</Data>
-        <Data AD_Column_ID="97371" Column="EntityType">ECA40</Data>
+        <Data AD_Column_ID="97371" Column="EntityType">LVE</Data>
         <Data AD_Column_ID="97372" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="97373" Column="IsActive">true</Data>
         <Data AD_Column_ID="97374" Column="Name">Prevenir Anulación/Reverso de Facturas de Venta Fiscales</Data>

--- a/xml/migration/5040_LVE_Validacion_para_prevenir_reverso_de_facturas_fiscales.xml
+++ b/xml/migration/5040_LVE_Validacion_para_prevenir_reverso_de_facturas_fiscales.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Validacion para prevenir reverso de facturas fiscales" ReleaseNo="3.9.4" SeqNo="81001380">
+    <Comments>para</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="54786" Action="I" Record_ID="50139" Table="AD_SetupDefinition">
+        <Data AD_Column_ID="97364" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="97365" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="97366" Column="AD_SetupDefinition_ID">50139</Data>
+        <Data AD_Column_ID="97367" Column="Classname">org.erpya.lve.setup.FiscalSalesInvoiceValidation</Data>
+        <Data AD_Column_ID="97368" Column="Created">2026-04-13 11:42:07.376</Data>
+        <Data AD_Column_ID="97369" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="97370" Column="Description">Este setup impide anular o revertir facturas de venta fiscales, asegurando la integridad de la información y forzando el uso de notas de crédito para correcciones.</Data>
+        <Data AD_Column_ID="97371" Column="EntityType">ECA40</Data>
+        <Data AD_Column_ID="97372" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="97373" Column="IsActive">true</Data>
+        <Data AD_Column_ID="97374" Column="Name">Prevenir Anulación/Reverso de Facturas de Venta Fiscales</Data>
+        <Data AD_Column_ID="97375" Column="Updated">2026-04-13 11:42:07.376</Data>
+        <Data AD_Column_ID="97376" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="97377" Column="UUID">1a603085-86c4-4947-8dce-4eb1b5bf0c7c</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
# 🚀 Implementación de Validador de Facturas de Venta Fiscales

## 🏗️ Clase de Setup
`org.erpya.lve.setup.FiscalSalesInvoiceValidation`

---

## 📌 Nombre
**Prevenir Anulación/Reverso de Facturas de Venta Fiscales**

---

## 📝 Descripción del cambio

Se implementa un **validador de modelo** encargado de proteger la integridad de las **facturas de venta fiscales** 🧾.

Este setup bloquea las siguientes acciones cuando la factura cumple con las condiciones de ser:

- ✔️ Documento **Completado**
- ✔️ Transacción de **Ventas**
- ✔️ Marcado como **Documento Fiscal**

### 🚫 Acciones restringidas:
- Anular factura
- Reversar documento
- Reversar causación
- Reversar y corregir

---

## 🛡️ Objetivo

Garantizar que las facturas fiscales no puedan ser modificadas directamente una vez completadas, asegurando el cumplimiento de las reglas contables y fiscales.

📌 Las correcciones deberán realizarse mediante mecanismos controlados como **Notas de Crédito**.

---

## 🔧 Validador de Modelo
`org.erpya.lve.model.validator.FiscalSalesInvoice`

---

## ✨ Resultado

✔️ Mayor control fiscal  
✔️ Integridad de datos contables  
✔️ Flujo correcto de correcciones  
✔️ Cumplimiento de normativa interna  

---